### PR TITLE
adds time units handling for speedscope format

### DIFF
--- a/pkg/convert/speedscope/json.go
+++ b/pkg/convert/speedscope/json.go
@@ -9,13 +9,6 @@ const (
 	profileEvented = "evented"
 	profileSampled = "sampled"
 
-	unitNone         = "none"
-	unitNanoseconds  = "nanoseconds"
-	unitMicroseconds = "microseconds"
-	unitMilliseconds = "milliseconds"
-	unitSeconds      = "seconds"
-	unitBytes        = "bytes"
-
 	eventOpen  = "O"
 	eventClose = "C"
 )
@@ -43,7 +36,7 @@ type frame struct {
 type profile struct {
 	Type       string
 	Name       string
-	Unit       string
+	Unit       unit
 	StartValue float64
 	EndValue   float64
 

--- a/pkg/convert/speedscope/parser.go
+++ b/pkg/convert/speedscope/parser.go
@@ -71,6 +71,7 @@ func parseOne(prof *profile, putInput storage.PutInput, frames []frame, multi bo
 	}
 
 	// TODO(petethepig): We need a way to tell if it's a default or a value set by user
+	//   See https://github.com/pyroscope-io/pyroscope/issues/1598
 	if putInput.SampleRate == 100 {
 		putInput.SampleRate = uint32(prof.Unit.defaultSampleRate())
 	}

--- a/pkg/convert/speedscope/speedscope_test.go
+++ b/pkg/convert/speedscope/speedscope_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Speedscope", func() {
 		ingester := new(mockIngester)
 		profile := &RawProfile{RawData: data}
 
-		md := ingestion.Metadata{Key: key}
+		md := ingestion.Metadata{Key: key, SampleRate: 100}
 		err = profile.Parse(context.Background(), ingester, nil, md)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -40,11 +40,12 @@ var _ = Describe("Speedscope", func() {
 
 		Expect(input.Units).To(Equal(metadata.SamplesUnits))
 		Expect(input.Key.Normalized()).To(Equal("foo{}"))
-		expectedResult := `a;b 5
-a;b;c 5
-a;b;d 4
+		expectedResult := `a;b 500
+a;b;c 500
+a;b;d 400
 `
 		Expect(input.Val.String()).To(Equal(expectedResult))
+		Expect(input.SampleRate).To(Equal(uint32(10000)))
 	})
 
 	It("Can parse a sample-format profile", func() {
@@ -57,7 +58,7 @@ a;b;d 4
 		ingester := new(mockIngester)
 		profile := &RawProfile{RawData: data}
 
-		md := ingestion.Metadata{Key: key}
+		md := ingestion.Metadata{Key: key, SampleRate: 100}
 		err = profile.Parse(context.Background(), ingester, nil, md)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -66,10 +67,11 @@ a;b;d 4
 		input := ingester.actual[0]
 		Expect(input.Units).To(Equal(metadata.SamplesUnits))
 		Expect(input.Key.Normalized()).To(Equal("foo.seconds{x=y}"))
-		expectedResult := `a;b 5
-a;b;c 5
-a;b;d 4
+		expectedResult := `a;b 500
+a;b;c 500
+a;b;d 400
 `
 		Expect(input.Val.String()).To(Equal(expectedResult))
+		Expect(input.SampleRate).To(Equal(uint32(100)))
 	})
 })

--- a/pkg/convert/speedscope/units.go
+++ b/pkg/convert/speedscope/units.go
@@ -1,0 +1,79 @@
+package speedscope
+
+import (
+	"fmt"
+
+	"github.com/pyroscope-io/pyroscope/pkg/storage/metadata"
+	"github.com/pyroscope-io/pyroscope/pkg/storage/segment"
+)
+
+type unit string
+
+const (
+	unitNone         = unit("none")
+	unitNanoseconds  = unit("nanoseconds")
+	unitMicroseconds = unit("microseconds")
+	unitMilliseconds = unit("milliseconds")
+	unitSeconds      = unit("seconds")
+	unitBytes        = unit("bytes")
+)
+
+// This number defines how much precision we want to keep when converting
+// from doubles to integers
+var timePrecisionMultiplier = 100
+
+func (u unit) defaultSampleRate() uint32 {
+	switch u {
+	case unitNanoseconds:
+		return uint32(timePrecisionMultiplier) * 1000 * 1000 * 1000
+	case unitMicroseconds:
+		return uint32(timePrecisionMultiplier) * 1000 * 1000
+	case unitMilliseconds:
+		return uint32(timePrecisionMultiplier) * 1000
+	case unitSeconds:
+		return uint32(timePrecisionMultiplier)
+	case unitNone:
+		// 100 is a common default value for sample rate
+		return uint32(timePrecisionMultiplier) * 100
+	case unitBytes:
+		return 0
+	default:
+		panic("unknown unit " + u)
+	}
+}
+
+func (u unit) precisionMultiplier() uint64 {
+	switch u {
+	case unitNanoseconds:
+		return uint64(timePrecisionMultiplier)
+	case unitMicroseconds:
+		return uint64(timePrecisionMultiplier)
+	case unitMilliseconds:
+		return uint64(timePrecisionMultiplier)
+	case unitSeconds:
+		return uint64(timePrecisionMultiplier)
+	case unitNone:
+		return uint64(timePrecisionMultiplier)
+	case unitBytes:
+		return 1
+	default:
+		panic("unknown unit " + u)
+	}
+}
+
+func (u unit) chooseMetadataUnit() metadata.Units {
+	switch u {
+	case unitBytes:
+		return metadata.BytesUnits
+	default:
+		return metadata.SamplesUnits
+	}
+}
+
+func (u unit) chooseKey(orig *segment.Key) *segment.Key {
+	// This means we'll have duplicate keys if multiple profiles have the same units. Probably ok.
+	name := fmt.Sprintf("%s.%s", orig.AppName(), u)
+	result := orig.Clone()
+	result.Add("__name__", name)
+	return result
+}


### PR DESCRIPTION
This patch does a few things:
* since I was adding a lot of unit-related code I created a dedicated go type for speedscope units, and I moved all unit-related code to a separate file (`units.go`)
* to address the problem with double values I introduced a concept of `precisionMultiplier` and set it to `100`. All incoming values get multiplied by this `precisionMultiplier` before being converted from doubles to integers. This means that we'll get 2 digit precision when it comes to displaying the data, which is consistent with precision of our formatters on the frontend. 
* To make sure that the frontend shows correct values, the sample rate is set accordingly. For seconds it's set to `100`. For milliseconds it's `100 * 1000` and so on.
* byte values don't get multiplied and their sample rate is set to 0, which is consistent with our other converters, e.g pprof converter.
* `unit = none` is somewhat of a special case. it gets treated as if it's a profile with sample rate set to 100.
* a user can override sample rate if they want to do so, however, we don't handle the case when they want to specify sample rate of 100 (@vasi-stripe mentioned it and I made an issue, this is something we should improve at some point https://github.com/pyroscope-io/pyroscope/issues/1598)

cc @vasi-stripe & @kolesnikovae